### PR TITLE
updates regex for Google Font urls

### DIFF
--- a/index.js
+++ b/index.js
@@ -266,10 +266,10 @@ function loadGoogleFont(fontLink) {
 
   // Function to extract the font name from a Google Font URL
   function extractFontName(fontLink) {
-    var fontNameMatch = fontLink.match(/family=([^&]+)/);
+    var fontNameMatch = fontLink.match(/.+family=([^&]+)/);
     if (fontNameMatch && fontNameMatch[1]) {
-      var fontName = fontNameMatch[1].split(":wght@")[0];
-      return decodeURIComponent(fontName.replace(/\+/g, " "));
+      var fontName = fontNameMatch[1].split(":")[0];
+      return decodeURIComponent(fontName.replaceAll("+", " "));
     }
     return "";
   }


### PR DESCRIPTION
In order to make sure the extension was working, I decided to select a very distinct font. (It's practically illegible in ST but that's not the point): https://fonts.google.com/specimen/DM+Serif+Display

1. Click "Get font" in the upper right
2. "Get embed code"
3. "@import"

The URL it gives is `https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&display=swap`

Once I looked at the code, It became clear as to why this didn't work. It currently only expects `:wght@` so I changed it to split on any colon. None of the Google Fonts have a colon in their name, so this shouldn't be an issue.

I also made it so it can now handle URLs such as https://fonts.googleapis.com/css2?family=DM+Serif+Display:ital@0;1&family=Noto+Serif:ital,wght@0,100..900;1,100..900&family=Roboto:ital,wght@0,100;0,300;0,400;0,500;0,700;0,900;1,100;1,300;1,400;1,500;1,700;1,900&display=swap

This occurs when a user has more than one font selected. The most recent selection is last on the list, so I added `.+` to the regex to make it only capture the last occurrence of `family=([^&]+)`